### PR TITLE
Addresses issue #5.

### DIFF
--- a/lib/Flickr/API2/Photo.pm
+++ b/lib/Flickr/API2/Photo.pm
@@ -27,6 +27,10 @@ description
 
 path_alias
 
+license
+
+tags
+
 =cut
 
 has 'id' => (
@@ -70,6 +74,8 @@ has 'url_o' => (
 );
 has 'description' => ( is => 'rw' );
 has 'path_alias' => ( is => 'rw' );
+has 'license' => ( is => 'rw' );
+has 'tags' => ( is => 'rw' );
 
 =head1 METHODS
 

--- a/lib/Flickr/API2/Photos.pm
+++ b/lib/Flickr/API2/Photos.pm
@@ -30,6 +30,8 @@ sub by_id {
     $p->owner_name($info->{owner}{realname});
     $p->owner_id($info->{owner}{nsid});
     $p->path_alias($info->{owner}{username});
+    $p->license($info->{license});
+    $p->tags($info->{tags}{tag});
 
     return $p;
 }


### PR DESCRIPTION
Added license and tags reference to photos->by_id sub.

```
$result = $api->photos->by_id([<photo_id>]);
print "Licnese: " . $result->{license} . "\n";
print "Raw tags:  ";
for my $i (@{ $result->{tags} } ){
        print $i->{raw} . "\n";
}
```
