### PR TITLE
use ssl api endpoint by default

### DIFF
--- a/lib/Flickr/API2.pm
+++ b/lib/Flickr/API2.pm
@@ -21,7 +21,7 @@ sub new {
     my $self = {
         _raw => Flickr::API2::Raw->new($options),
         rest_uri => $options->{rest_uri}
-          || 'http://api.flickr.com/services/rest/',
+          || 'https://api.flickr.com/services/rest/',
     };
 
     bless $self, $class;


### PR DESCRIPTION
per http://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/
