### PR TITLE
Fix photo page URL generation

### DIFF
--- a/lib/Flickr/API2/Photo.pm
+++ b/lib/Flickr/API2/Photo.pm
@@ -188,7 +188,7 @@ Returns the URL for this photo's page on Flickr.
 sub page_url {
     my $self = shift;
     return sprintf('http://flickr.com/photos/%s/%d',
-        ($self->path_alias || $self->owner_name || $self->owner_id),
+        ($self->path_alias || $self->owner_id),
         $self->id
     );
 }


### PR DESCRIPTION
When generating a photo page URL, the user's pretty name isn't always usable in the URL.

So if a user's name is "John Doe III" there's no reason their photos should be at "/photos/John%20Doe%III"

I removed the use of the owner_name in generating a photo's page URL, to keep from generating broken URLs.